### PR TITLE
Fix/fe 157 homepage intro mobile issue

### DIFF
--- a/src/client/routes/index.tsx
+++ b/src/client/routes/index.tsx
@@ -23,8 +23,8 @@ export const Route = createFileRoute("/")({
           </div>
         </div>
 
-        <div className="flex flex-col items-center bg-black px-2 py-6 md:px-8 lg:px-12">
-          <div className="relative mt-8 w-9/12 rounded-2xl bg-gradient-to-r from-saseBlue via-[#7DC242] to-saseGreen p-[4px] lg:mt-0">
+        <div className="flex flex-col items-center bg-black px-0 py-14 md:px-8 lg:px-12">
+          <div className="relative w-9/12 rounded-2xl bg-gradient-to-r from-saseBlue via-[#7DC242] to-saseGreen p-[4px]">
             <div className="flex h-full flex-col rounded-2xl bg-gray-950 p-4 text-center lg:p-10 lg:text-start">
               <h1 className="pb-12 font-oswald text-3xl font-medium text-white sm:text-5xl">University of Florida Chapter</h1>
               <div>

--- a/src/client/routes/index.tsx
+++ b/src/client/routes/index.tsx
@@ -23,9 +23,9 @@ export const Route = createFileRoute("/")({
           </div>
         </div>
 
-        <div className="flex flex-col items-center bg-black p-12">
-          <div className="relative w-9/12 rounded-2xl bg-gradient-to-r from-saseBlue via-[#7DC242] to-saseGreen p-[4px]">
-            <div className="flex h-full flex-col rounded-2xl bg-gray-950 p-10">
+        <div className="flex flex-col items-center bg-black px-2 py-6 md:px-8 lg:px-12">
+          <div className="relative mt-8 w-9/12 rounded-2xl bg-gradient-to-r from-saseBlue via-[#7DC242] to-saseGreen p-[4px] lg:mt-0">
+            <div className="flex h-full flex-col rounded-2xl bg-gray-950 p-4 text-center lg:p-10 lg:text-start">
               <h1 className="pb-12 font-oswald text-3xl font-medium text-white sm:text-5xl">University of Florida Chapter</h1>
               <div>
                 {/* Video for sm-xl screens */}
@@ -47,14 +47,14 @@ export const Route = createFileRoute("/")({
                   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
                   allowFullScreen
                 ></iframe>
-                <p className="font-redhat text-xl text-white">
+                <p className="font-redhat text-lg text-white md:text-xl">
                   The <span className="font-semibold">Society of Asian Scientists & Engineers </span> is a vibrant and dynamic organization at the
                   University of Florida. We are committed to fostering meaningful connections across cultures and empowering{" "}
                   <span className="font-semibold">Asian Pacific Islander Desi American (APIDA) </span>
                   professionals in <span className="font-semibold">science and engineering</span>.
                 </p>
                 <br />
-                <p className="font-redhat text-xl text-white">
+                <p className="font-redhat text-lg text-white md:text-xl">
                   Through <span className="font-semibold">engaging meetings and events</span>, we provide a nurturing environment where you can
                   acquire <span className="font-semibold">essential skills and knowledge </span>
                   to excel in the professional world. Our <span className="font-semibold">inclusive community </span>


### PR DESCRIPTION


Adjusted padding, text align, text size. All to make intro section to SASE Website not garbage on mobile 

Appearance after changes: 
<img width="416" alt="Screenshot 2025-02-03 at 4 28 56 PM" src="https://github.com/user-attachments/assets/e190ba5d-ed1a-4cec-aa0d-4e63555beab8" />
<img width="409" alt="Screenshot 2025-02-03 at 4 29 05 PM" src="https://github.com/user-attachments/assets/ae4b4f51-354f-4184-bcef-d523a3f07731" />

