### PR TITLE
changed sign up to include email

### DIFF
--- a/src/client/components/AuthForm.tsx
+++ b/src/client/components/AuthForm.tsx
@@ -85,7 +85,7 @@ const AuthForm = ({ additionalButton, buttonLabel, isSignUp = false, linkRoute, 
               message: "Username must be 12 characters or fewer!",
             },
           })}
-          placeholder="Username"
+          placeholder="Username or Email"
           className="h-12 p-4"
         />
       </StyledFormField>

--- a/src/client/components/AuthForm.tsx
+++ b/src/client/components/AuthForm.tsx
@@ -85,7 +85,7 @@ const AuthForm = ({ additionalButton, buttonLabel, isSignUp = false, linkRoute, 
               message: "Username must be 12 characters or fewer!",
             },
           })}
-          placeholder="Username or Email"
+          placeholder="Username or email"
           className="h-12 p-4"
         />
       </StyledFormField>


### PR DESCRIPTION
Issue #236:
- Changed the input box's preview text to be "Username or email" on sign in page.