### PR TITLE
Make all blog cards the same height regardless of content

### DIFF
--- a/src/client/components/blogs/BlogCard.tsx
+++ b/src/client/components/blogs/BlogCard.tsx
@@ -42,7 +42,7 @@ const BlogCard: React.FC<BlogCardProps> = ({ blog, expandedBlogId, isEditing, se
         <section
           className={cn(
             "relative z-10 flex flex-col items-start rounded-[50px] border-2 border-border bg-white p-12",
-            "h-[600px] w-full shadow-lg transition sm:flex-col",
+            "h-[450px] w-full shadow-lg transition sm:h-[600px] sm:flex-col",
           )}
         >
           {/* image */}


### PR DESCRIPTION

## 📝 Description

Made all blog cards the same height (700px) regardless of content length.

---

## 🔗 Related Issue(s)

Related to #393 

---

## 🧪 How to Test

Include clear steps so reviewers can verify your changes.

**Example:**

1. Pull this branch
2. Run `bun dev`
3. Navigate to `/blogs`
4. Verify all blog cards are the same height
5. Verify preview text is truncated properly

---

## 📸 Screenshots (if applicable)

Before:
<img width="912" height="628" alt="image" src="https://github.com/user-attachments/assets/81df6b0f-5ff6-4fa4-90d2-c6c498f80b7f" />


After: 
<img width="900" height="715" alt="image" src="https://github.com/user-attachments/assets/56bb4764-c1e1-40f0-b8cd-46e56a458b60" />


---

## ✅ Checklist

- My code follows the project’s coding conventions
- I ran `bun fix` and fixed all warnings/errors
- I’ve tested the changes locally
- I’ve added or updated comments and documentation where needed
- This PR is ready for review

---

