### PR TITLE
Events gallery

### DIFF
--- a/src/client/components/gallery/GalleryYearbook.tsx
+++ b/src/client/components/gallery/GalleryYearbook.tsx
@@ -6,36 +6,25 @@ type Props = {
 };
 
 const GalleryYearbook = ({ year }: Props) => {
-  const displayLabel = year === "2023-2024" ? "UF SASE 2023–2024" : "UF SASE 2024–2025";
-
   const previewImage = year === "2023-2024" ? imageUrls["fall2023_7.JPG"] : imageUrls["fall2024_11.JPG"];
 
   return (
-    <div className="flex w-full max-w-4xl flex-col items-center">
-      {/* Title */}
-      <div className="mb-6 mt-4 text-center">
-        <h3 className="font-oswald text-5xl font-bold text-background">{displayLabel}</h3>
-      </div>
+    <div className="w-full max-w-3xl">
+      <div className="relative">
+        <div className="flex items-stretch">
+          {/* Left rectangle */}
+          <div className="w-10 shrink-0 rounded-[4px] bg-[#c9ddff]" />
 
-      {/* Frame block */}
-      <div className="relative w-full">
-        {/* Outer large rounded rectangle */}
-        <div className="rounded-[32px] bg-[#e0ecff] p-4 shadow-[0_0_0_6px_#8cb8f7]">
-          {/* Left vertical bar */}
-          <div className="flex">
-            <div className="mr-4 w-10 rounded-[20px] bg-[#c9ddff]" />
-
-            {/* Inner frame */}
-            <div className="flex-1 rounded-[20px] border-[10px] border-[#9dc4ff] bg-white p-2">
-              <div className="aspect-[4/3] overflow-hidden rounded-[12px] bg-gray-100">
-                <img src={previewImage} className="h-full w-full object-cover" />
-              </div>
+          {/* Frame */}
+          <div className="ml-3 flex-1 rounded-[4px] border-[10px] border-[#bcdcff] md:border-[14px]">
+            <div className="aspect-[4/3] w-full overflow-hidden rounded-[4px] bg-white">
+              <img src={previewImage} alt="Yearbook preview" className="h-full w-full object-cover" />
             </div>
           </div>
         </div>
 
-        {/* SASE logo overlapping bottom-right */}
-        <img src={imageUrls["SASELogoWithoutText.png"]} className="absolute -bottom-12 -right-12 w-40 drop-shadow-lg" />
+        {/* SASE logo */}
+        <img src={imageUrls["SASELogoWithoutText.png"]} className="absolute -bottom-6 -right-2 w-20 md:-bottom-10 md:-right-20 md:w-60" />
       </div>
     </div>
   );

--- a/src/client/components/gallery/GalleryZipExtraction.tsx
+++ b/src/client/components/gallery/GalleryZipExtraction.tsx
@@ -1,62 +1,94 @@
 import { imageUrls } from "@assets/imageUrls";
-import React, { useState } from "react";
-import { FaChevronLeft, FaChevronRight } from "react-icons/fa6";
+import React, { useEffect, useState } from "react";
 
 interface ZipProps {
   slideshow: string;
 }
 
+const MAX_MOBILE_ITEMS = 4;
+
 const GalleryZipExtraction: React.FC<ZipProps> = ({ slideshow }) => {
-  // List of image paths inside the 'public/assets' folder
-  const fall2024_images = [imageUrls["fall2024_1.JPG"], imageUrls["fall2024_4.JPG"], imageUrls["fall2024_5.JPG"], imageUrls["fall2024_6.JPG"]];
+  const fall2024_images = [
+    imageUrls["fall2024_1.JPG"],
+    imageUrls["fall2024_4.JPG"],
+    imageUrls["fall2024_5.JPG"],
+    imageUrls["fall2024_6.JPG"],
+    imageUrls["fall2024_7.JPG"],
+    imageUrls["fall2024_9.JPG"],
+    imageUrls["fall2024_10.JPG"],
+  ];
 
-  const spring2024_images = [imageUrls["fall2024_7.JPG"], imageUrls["fall2024_9.JPG"], imageUrls["fall2024_10.JPG"], imageUrls["fall2024_2.jpg"]];
+  const spring2024_images = [
+    imageUrls["spring2024_1.JPG"],
+    imageUrls["spring2024_2.JPG"],
+    imageUrls["spring2024_3.JPG"],
+    imageUrls["spring2024_4.JPG"],
+    imageUrls["spring2024_5.jpg"],
+    imageUrls["spring2024_6.JPG"],
+  ];
 
-  const fall2023_images = [imageUrls["fall2024_3.jpeg"], imageUrls["fall2024_8.jpg"], imageUrls["fall2024_12.jpg"], imageUrls["fall2024_13.jpg"]];
+  const fall2023_images = [
+    imageUrls["fall2023_4.JPG"],
+    imageUrls["fall2023_5.jpg"],
+    imageUrls["fall2023_6.JPG"],
+    imageUrls["fall2023_7.JPG"],
+    imageUrls["fall2023_8.JPG"],
+    imageUrls["fall2023_9.JPG"],
+  ];
 
-  let images;
+  let images: Array<string> = [];
+  if (slideshow === "Fall 2024") images = fall2024_images;
+  else if (slideshow === "Spring 2024") images = spring2024_images;
+  else images = fall2023_images;
 
-  if (slideshow == "Fall 2024") {
-    images = fall2024_images;
-  } else if (slideshow == "Spring 2024") {
-    images = spring2024_images;
-  } else {
-    images = fall2023_images;
-  }
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [isDesktop, setIsDesktop] = useState(false);
 
-  // State to track the current index of the image being displayed
-  const [currentIndex, setCurrentIndex] = useState<number>(0);
+  useEffect(() => {
+    if (typeof window === "undefined") return;
 
-  // Function to go to the next image
-  const nextImage = () => {
-    setCurrentIndex((prevIndex) => (prevIndex + 1) % images.length); // Wrap around to the first image
-  };
+    const mediaQuery = window.matchMedia("(min-width: 768px)");
 
-  // Function to go to the previous image
-  const prevImage = () => {
-    setCurrentIndex(
-      (prevIndex) => (prevIndex - 1 + images.length) % images.length, // Wrap around to the last image
-    );
-  };
+    // Set initial value
+    setIsDesktop(mediaQuery.matches);
+
+    // Listener with correct typing
+    const handler = (event: MediaQueryListEvent) => {
+      setIsDesktop(event.matches);
+    };
+
+    mediaQuery.addEventListener("change", handler);
+    return () => mediaQuery.removeEventListener("change", handler);
+  }, []);
+
+  const visibleImages = isDesktop || isExpanded ? images : images.slice(0, MAX_MOBILE_ITEMS);
+
+  const canToggleOnMobile = !isDesktop && images.length > MAX_MOBILE_ITEMS;
 
   return (
-    <div className="flex w-full items-center justify-center">
-      <div className="cursor-pointer px-[8%] transition hover:scale-125 hover:opacity-45" onClick={prevImage}>
-        {/* Left Arrow */}
-        <button className="text-4xl">
-          <FaChevronLeft />
-        </button>
+    <div className="w-full">
+      <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        {visibleImages.map((src, i) => (
+          <div key={i} className="overflow-hidden rounded-[6px] border border-gray-200 bg-white">
+            <div className="aspect-[4/3] w-full">
+              <img src={src} className="h-full w-full object-cover" />
+            </div>
+          </div>
+        ))}
       </div>
-      <div className="rounded-lg shadow-[10px_10px_0px_0px_rgb(6,104,179)]">
-        {/* Image */}
-        <img src={images[currentIndex]} alt={`Image ${currentIndex + 1}`} className="w-full rounded-lg border-2 border-black object-cover" />
-      </div>
-      <div className="cursor-pointer px-[8%] transition hover:scale-125 hover:opacity-45" onClick={nextImage}>
-        {/* Right Arrow */}
-        <button className="text-4xl">
-          <FaChevronRight />
-        </button>
-      </div>
+
+      {/* MOBILE COLLAPSE BUTTON */}
+      {canToggleOnMobile && (
+        <div className="mt-6 flex justify-center md:hidden">
+          <button
+            type="button"
+            onClick={() => setIsExpanded((v) => !v)}
+            className="inline-flex items-center justify-center rounded-full border border-black bg-saseBlue px-5 py-2 font-redhat text-sm tracking-[0.12em] text-white shadow-[3px_3px_0_0_rgba(0,0,0,0.35)] transition-transform duration-150 hover:-translate-x-[1px] hover:-translate-y-[1px] hover:shadow-[4px_4px_0_0_rgba(0,0,0,0.3)]"
+          >
+            {isExpanded ? "Show fewer photos" : "Show more photos"}
+          </button>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/client/components/gallery/SlideshowIndicator.tsx
+++ b/src/client/components/gallery/SlideshowIndicator.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+
+type SlideshowIndicatorProps = {
+  label: string;
+};
+
+const SlideshowIndicator = ({ label }: SlideshowIndicatorProps) => {
+  // remove spaces so it stacks nicely
+  const chars = label.replace(/\s+/g, "").split("");
+
+  return (
+    <div className="flex select-none flex-col items-center gap-2 sm:gap-3 md:gap-4">
+      {chars.map((c, idx) => {
+        const isYearChar = /\d/.test(c); // digits -> year
+
+        const baseClasses =
+          "flex items-center justify-center rounded-full font-redhat font-semibold text-white shadow-[0_3px_0_rgba(0,0,0,0.25)] " +
+          "h-10 w-10 border-[2px] text-base " +
+          "sm:h-11 sm:w-11 sm:border-[3px] sm:text-lg " +
+          "md:h-12 md:w-12 md:border-[4px] md:text-xl";
+
+        const colorClasses = isYearChar ? "bg-saseGreen border-saseGreen" : "bg-saseBlue border-saseBlue";
+
+        return (
+          <div key={idx} className={`${baseClasses} ${colorClasses}`}>
+            {c}
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default SlideshowIndicator;

--- a/src/client/routes/gallery.tsx
+++ b/src/client/routes/gallery.tsx
@@ -4,10 +4,19 @@ import { useEffect, useState } from "react";
 import { IoMdLink, IoMdPlay } from "react-icons/io";
 import GalleryYearbook from "../components/gallery/GalleryYearbook";
 import GalleryZipExtraction from "../components/gallery/GalleryZipExtraction";
+import SlideshowIndicator from "../components/gallery/SlideshowIndicator";
 import { applyOmbreDivider } from "../utils/ombre-divider.js";
 import { seo } from "../utils/seo";
 
-const slideshowLinks: Record<string, string> = {
+const slideshowLabels = {
+  "Fall 2024": "FALL 2024",
+  "Spring 2024": "SPRING 2024",
+  "Fall 2023": "FALL 2023",
+} as const;
+
+type SlideshowKey = keyof typeof slideshowLabels;
+
+const slideshowLinks: Record<SlideshowKey, string> = {
   "Fall 2024": "https://docs.google.com/document/d/1gjG2aHkh-IYXLQ5vTfmd6uphP7AYYN0M4liorjPt77k/edit?tab=t.0",
   "Spring 2024": "https://docs.google.com/document/d/1SohQfPM2D8fQhf4vkeWPfC9xTE3my4XTfVA-BNYYA9s/edit?tab=t.0",
   "Fall 2023": "https://docs.google.com/document/d/18brpCElaHqD-rFcKd2eG4FGfjnBWXSthrI-aNdqoHYk/edit?tab=t.0",
@@ -37,14 +46,14 @@ export const Route = createFileRoute("/gallery")({
     }),
   ],
   component: () => {
-    const [slideshow, setSlideshow] = useState<string>("Fall 2024");
+    const [slideshow, setSlideshow] = useState<SlideshowKey>("Fall 2024");
     const [activeYearbook, setActiveYearbook] = useState<YearbookId>("2024-2025");
 
     useEffect(() => {
       applyOmbreDivider();
     }, []);
 
-    const entries = Object.entries(slideshowLinks);
+    const entries = Object.entries(slideshowLinks) as Array<[SlideshowKey, string]>;
     const previewHref = yearbookLinks[activeYearbook];
 
     return (
@@ -56,55 +65,68 @@ export const Route = createFileRoute("/gallery")({
 
         {/* Main gallery grid */}
         <section className="mx-auto mt-16 max-w-6xl px-4 md:px-8">
-          <div className="rounded-3xl bg-white/80 px-4 py-6 shadow-[0_10px_0_0_rgb(203,203,212)] md:px-6 md:py-8">
-            <GalleryZipExtraction slideshow={slideshow} />
+          <div className="flex gap-10">
+            {/* LEFT VERTICAL INDICATOR – only the active slideshow */}
+            <div className="flex flex-col items-center">
+              <SlideshowIndicator label={slideshowLabels[slideshow]} />
+            </div>
+
+            {/* SLIDESHOW */}
+            <div className="flex-1">
+              <GalleryZipExtraction slideshow={slideshow} />
+            </div>
           </div>
         </section>
 
         {/* Google Drive Links box */}
         <section className="mx-auto mt-16 max-w-4xl px-4 md:px-8">
-          <div className="flex flex-col gap-6 rounded-3xl border-[3px] border-black bg-white px-8 py-8 md:flex-row md:items-center">
+          <div className="flex flex-col gap-4 rounded-2xl border-[4px] border-black bg-white px-4 py-5 md:flex-row md:items-center md:gap-6 md:px-8 md:py-8">
             {/* Left text */}
-            <div className="flex flex-col items-center md:items-start">
-              <p className="text-center font-oswald text-3xl leading-tight md:text-3xl">
-                <span className="block text-saseBlue">Google</span>
-                <span className="block text-saseBlue">Drive</span>
-                <span className="block text-saseGreen">Links</span>
+            <div className="-mt-1 flex flex-col items-center md:items-start">
+              <p className="text-center font-oswald text-2xl leading-tight md:text-3xl">
+                <span className="text-saseBlue">
+                  Google <span className="inline md:block">Drive</span>
+                </span>
+                <span className="-mt-1 block text-saseGreen">Links</span>
               </p>
             </div>
 
             {/* Divider */}
-            <div className="hidden h-28 w-[2px] bg-black md:block" />
+            <div className="hidden h-32 w-[4px] bg-black md:block" />
 
             {/* Right: semesters grid */}
             <div className="flex-1">
-              <div className="grid grid-cols-1 gap-y-8 sm:grid-cols-3 sm:gap-y-10">
+              <div className="grid grid-cols-1 gap-y-4 sm:grid-cols-3 sm:gap-y-8">
                 {entries.map(([label, link]) => (
-                  <div key={label} className="flex flex-col items-center gap-3">
-                    {/* Label – changes slideshow only */}
-                    <button type="button" onClick={() => setSlideshow(label)} className="font-redhat text-lg font-medium hover:underline">
+                  <div key={label} className="flex flex-col items-center gap-1 md:gap-3">
+                    {/* Label */}
+                    <button
+                      type="button"
+                      onClick={() => setSlideshow(label)}
+                      className="font-redhat text-base font-medium hover:underline md:text-lg"
+                    >
                       {label}
                     </button>
 
                     {/* Icons row */}
-                    <div className="flex gap-3">
-                      {/* Link icon – opens Drive */}
+                    <div className="flex gap-2 md:gap-3">
+                      {/* Link icon */}
                       <a
                         href={link}
                         target="_blank"
                         rel="noreferrer"
-                        className="flex h-8 w-8 items-center justify-center rounded-[6px] border-[2px] border-[#3f8f35] text-[#3f8f35] transition hover:bg-[#e9f7e7]"
+                        className="flex h-7 w-7 items-center justify-center rounded-[6px] border-[3px] border-[#3f8f35] text-[#3f8f35] transition hover:bg-[#e9f7e7] md:h-8 md:w-8"
                       >
-                        <IoMdLink size={18} />
+                        <IoMdLink size={16} className="md:size-18" />
                       </a>
 
                       {/* Play icon */}
                       <button
                         type="button"
                         onClick={() => setSlideshow(label)}
-                        className="flex h-8 w-8 items-center justify-center rounded-[6px] border-[2px] border-saseBlue text-saseBlue transition hover:bg-[#e9f7e7]"
+                        className="flex h-7 w-7 items-center justify-center rounded-[6px] border-[3px] border-saseBlue text-saseBlue transition hover:bg-[#e9f7e7] md:h-8 md:w-8"
                       >
-                        <IoMdPlay size={18} />
+                        <IoMdPlay size={16} className="md:size-18" />
                       </button>
                     </div>
                   </div>
@@ -116,27 +138,26 @@ export const Route = createFileRoute("/gallery")({
 
         {/* Yearbook Section */}
         <section className="mx-auto mt-16 max-w-6xl px-4 md:px-8">
-          <h2 className="font-oswald text-4xl md:text-5xl">UF SASE YEARBOOK</h2>
+          <h2 className="mb-4 font-oswald text-4xl md:text-5xl">UF SASE YEARBOOK</h2>
 
-          <div className="mt-8 flex flex-col gap-6 md:flex-row">
-            {/* Left Year Buttons */}
+          <div className="mt-8 flex flex-col md:flex-row md:items-start md:gap-28">
+            {/* Year Buttons */}
             <div className="flex flex-col gap-3">
               {yearbooks.map((yb) => {
                 const isActive = activeYearbook === yb.id;
-
                 return (
                   <button
                     key={yb.id}
                     onClick={() => setActiveYearbook(yb.id)}
                     className={[
                       "inline-flex w-36 items-center justify-center",
-                      "rounded-[4px] border border-black",
+                      "rounded-[1px]",
                       "px-4 py-2 font-redhat text-[15px] font-medium tracking-[0.06em]",
                       "text-white",
                       "transition-transform duration-150",
                       isActive
-                        ? "bg-[#3f8f35] shadow-[1px_1px_0_0_rgba(0,0,0,0.4)]"
-                        : "bg-saseGreen shadow-[3px_3px_0_0_rgba(0,0,0,0.35)] hover:-translate-x-[1px] hover:-translate-y-[1px] hover:shadow-[4px_4px_0_0_rgba(0,0,0,0.35)]",
+                        ? "bg-[#3f8f35]"
+                        : "bg-saseGreen hover:-translate-x-[1px] hover:-translate-y-[1px] hover:shadow-[4px_4px_0_0_rgba(0,0,0,0.35)]",
                     ].join(" ")}
                   >
                     {yb.label}
@@ -145,13 +166,12 @@ export const Route = createFileRoute("/gallery")({
               })}
             </div>
 
-            {/* Yearbook Frame Component */}
-            <div className="flex flex-1 flex-col items-center">
+            {/* Frame and Preview */}
+            <div className="flex flex-1 flex-col items-center md:items-start">
               <GalleryYearbook year={activeYearbook} />
 
-              {/* Preview Button */}
-              <a href={previewHref} target="_blank" rel="noreferrer" className="mt-10">
-                <button className="inline-flex items-center justify-center rounded-[4px] border border-black bg-saseBlue px-7 py-2 font-redhat text-[16px] tracking-[0.12em] text-white shadow-[3px_3px_0_0_rgba(0,0,0,0.35)] transition-transform duration-150 hover:-translate-x-[2px] hover:-translate-y-[2px] hover:shadow-[5px_5px_0_0_rgba(0,0,0,0.3)]">
+              <a href={previewHref} target="_blank" rel="noreferrer" className="mt-6 self-center md:self-start">
+                <button className="inline-flex items-center justify-center rounded-[4px] border-[3px] border-black bg-saseBlue px-7 py-2 font-redhat text-[20px] tracking-[0.12em] text-white shadow-[3px_3px_0_0_rgba(0,0,0,0.35)] transition-transform duration-150 hover:-translate-x-[2px] hover:-translate-y-[2px] hover:shadow-[5px_5px_0_0_rgba(0,0,0,0.3)]">
                   Preview
                 </button>
               </a>


### PR DESCRIPTION
## 📝 Description

> Updates Events/gallery page with the Figma
> New slideshow style, yearbook preview design, mobile friendly collapse gallery

---

## 🧪 How to Test

1. Pull this branch
2. Run `bun install` and `bun dev`
3. Navigate to `/events/gallery`
4. Make sure slideshow previews are working and update
5. Check that links work and direct to correct ones

---

## 📸 Screenshots (if applicable)

Before
<img width="1900" height="862" alt="image" src="https://github.com/user-attachments/assets/9af9ac45-10e0-419d-925b-5029d8e5b2f9" />
<img width="1896" height="862" alt="image" src="https://github.com/user-attachments/assets/b4fc8c84-7bb5-4417-a8c8-60e223c5b815" />

After
<img width="1902" height="862" alt="image" src="https://github.com/user-attachments/assets/060c70ed-11ab-4a14-98de-d6561cb633a3" />
<img width="1915" height="863" alt="image" src="https://github.com/user-attachments/assets/2a75e892-fcb0-48f1-8738-e2743d824e1e" />


---