### PR TITLE
Added Alumni Bank table to the database with all relevant information

### DIFF
--- a/src/server/db/tables.ts
+++ b/src/server/db/tables.ts
@@ -233,3 +233,15 @@ export const company = sqliteTable("company", {
   role: text("role"),
   isCurrent: integer("is_current").default(0).notNull(),
 });
+
+// Alumni Bank table
+export const alumniBank = sqliteTable("alumni_bank", {
+  id: text("id")
+    .primaryKey()
+    .references(() => users.id, { onDelete: "cascade" }),
+  name: text("name").notNull(),
+  major: text("major").notNull(),
+  graduationYear: text("graduation_year").notNull(),
+  currentCompany: text("current_company").notNull(),
+  pastCompanies: text("past_companies", { mode: "json" }).$type<Array<string>>().notNull().default([]),
+});


### PR DESCRIPTION
#440  This defines the database schema for the alumni_bank table in the Drizzle ORM schema file.
Primary Key: id - References users.id
Data Types:
• name: Full name of alumni
• major: Academic major
• graduationYear: Stored as text for flexibility (e.g., "Spring 2023")
• currentCompany: Current employer name
• pastCompanies: Past employer names
