### PR TITLE
Auth middlware

### DIFF
--- a/src/server/api/auth.ts
+++ b/src/server/api/auth.ts
@@ -1,5 +1,6 @@
 import { db } from "@/server/db/db";
 import { VerificationTemplate } from "@/server/email/verification-template";
+import { requireSession } from "@/server/middleware/auth";
 import { createErrorResponse, createSuccessResponse, emailRegex, passwordRegex } from "@/shared/utils";
 import { oauthAccounts, pendingVerifications, professionalInfo, sessions, userRoleRelationship, users } from "@db/tables";
 import { SERVER_ENV } from "@server/env";
@@ -7,6 +8,7 @@ import { generateCodeVerifier, generateState, Google } from "arctic";
 import bcrypt from "bcryptjs";
 import { and, eq } from "drizzle-orm";
 import { Hono } from "hono";
+import { getCookie } from "hono/cookie";
 import { generateIdFromEntropySize } from "lucia";
 import { Resend } from "resend";
 
@@ -245,14 +247,13 @@ authRoutes.post("/auth/login", async (c) => {
 
 // Logout route
 authRoutes.post("/auth/logout", async (c) => {
-  const sessionId = c.req.header("Cookie")?.match(/sessionId=([^;]*)/)?.[1];
+  const sessionId = getCookie(c, "sessionId");
 
   if (!sessionId) {
     return createErrorResponse(c, "NO_SESSION", "No active session found", 401);
   }
 
   try {
-    // delete the session id row from the table
     await db.delete(sessions).where(eq(sessions.id, sessionId));
 
     return createSuccessResponse(c, null, "Successfully logged out");
@@ -263,26 +264,9 @@ authRoutes.post("/auth/logout", async (c) => {
 });
 
 // used for validating sessions
-authRoutes.get("/auth/session", async (c) => {
-  const sessionId = c.req.header("Cookie")?.match(/sessionId=([^;]*)/)?.[1];
-
-  if (!sessionId) {
-    return createErrorResponse(c, "NO_SESSION", "No active session", 401);
-  }
-
+authRoutes.get("/auth/session", requireSession, async (c) => {
   try {
-    const session = await db.select().from(sessions).where(eq(sessions.id, sessionId)).get();
-
-    if (!session) {
-      return createErrorResponse(c, "SESSION_NOT_FOUND", "Session not found", 401);
-    }
-
-    if (session.expiresAt < Date.now()) {
-      await db.delete(sessions).where(eq(sessions.id, sessionId));
-      // maybe renew session?
-      return createErrorResponse(c, "SESSION_EXPIRED", "Session expired", 401);
-    }
-
+    const session = c.get("session");
     const user = await db.select({ id: users.id, username: users.username }).from(users).where(eq(users.id, session.userId)).get();
 
     if (!user) {

--- a/src/server/api/profile.ts
+++ b/src/server/api/profile.ts
@@ -1,5 +1,5 @@
-import { isAdmin } from "@/server/api/roles";
 import { db } from "@/server/db/db";
+import { requireSession } from "@/server/middleware/auth";
 import { createErrorResponse, createSuccessResponse } from "@/shared/utils";
 import * as Schema from "@db/tables";
 import { updateUserSchema } from "@schema/userSchema";
@@ -32,26 +32,19 @@ const profileSelection = {
   graduationSemester: Schema.professionalInfo.graduationSemester,
 };
 
-profileRoutes.get("/profile", async (c) => {
+profileRoutes.get("/profile", requireSession, async (c) => {
   try {
-    const cookie = c.req.header("Cookie") || "";
-    const sessionIDMatch = cookie.match(/sessionId=([^;]*)/);
-    if (!sessionIDMatch) {
-      return createErrorResponse(c, "INVALID_SESSION", "Missing or invalid session ID", 400);
-    }
-    const sessionID = sessionIDMatch[1];
+    const session = c.get("session");
 
     const result = await db
       .select(profileSelection)
       .from(Schema.users)
-      .innerJoin(Schema.sessions, eq(Schema.users.id, Schema.sessions.userId))
       .innerJoin(Schema.professionalInfo, eq(Schema.users.id, Schema.professionalInfo.userId))
-      .where(eq(Schema.sessions.id, sessionID));
+      .where(eq(Schema.users.id, session.userId));
 
     if (result.length === 1) {
       return createSuccessResponse(c, result[0], "Profile retrieved successfully");
     } else if (result.length === 0) {
-      console.log(sessionID);
       return createErrorResponse(c, "NO_USER_FOUND", "No user found", 404);
     } else {
       return createErrorResponse(c, "MULTIPLE_USERS", "Multiple users", 500);
@@ -63,22 +56,16 @@ profileRoutes.get("/profile", async (c) => {
 });
 
 // update user information only (professional info updates go through /api/users/professional/:id)
-profileRoutes.patch("/profile", async (c) => {
+profileRoutes.patch("/profile", requireSession, async (c) => {
   try {
-    const cookie = c.req.header("Cookie") || "";
-    const sessionIDMatch = cookie.match(/sessionId=([^;]*)/);
-    if (!sessionIDMatch) {
-      return createErrorResponse(c, "INVALID_SESSION", "Missing or invalid session ID", 400);
-    }
-    const sessionID = sessionIDMatch[1];
-    const adminPerms = await isAdmin(sessionID);
-    const result = await db.select().from(Schema.sessions).where(eq(Schema.sessions.id, sessionID));
-
-    if (result.length === 0) {
-      return createErrorResponse(c, "INVALID_SESSION", "Invalid session", 400);
-    }
-
-    const userID = result[0].userId;
+    const session = c.get("session");
+    const userID = session.userId;
+    const userRoles = await db
+      .select({ role: Schema.userRoleRelationship.role })
+      .from(Schema.userRoleRelationship)
+      .where(eq(Schema.userRoleRelationship.userId, userID))
+      .all();
+    const adminPerms = userRoles.some((r) => r.role === "admin" || r.role === "board");
     const body = await c.req.json();
 
     // separate user fields from roles fields

--- a/src/server/api/roles.ts
+++ b/src/server/api/roles.ts
@@ -1,4 +1,5 @@
 import { db } from "@/server/db/db";
+import { requireRoles, requireSession } from "@/server/middleware/auth";
 import { createErrorResponse, createSuccessResponse } from "@/shared/utils";
 import * as Schema from "@db/tables";
 import { and, eq } from "drizzle-orm";
@@ -25,19 +26,9 @@ roleRoutes.get("/roles/:userID", async (c) => {
   }
 });
 
-roleRoutes.post("/roles/assign", async (c) => {
+roleRoutes.post("/roles/assign", requireSession, requireRoles(["admin", "board"]), async (c) => {
   try {
     const { role, userId } = await c.req.json();
-    const cookie = c.req.header("Cookie") || "";
-    console.log(cookie);
-    const sessionIDMatch = cookie.match(/sessionId=([^;]*)/);
-    if (!sessionIDMatch) {
-      return createErrorResponse(c, "INVALID_SESSION", "Missing or invalid session ID", 400);
-    }
-    const sessionID = sessionIDMatch[1];
-    if (!(await isAdmin(sessionID))) {
-      return createErrorResponse(c, "ASSIGN_ACTION_UNAUTHORIZED", "Assigning unauthorized: Admin role required", 403);
-    }
 
     const roleExist = await db.select().from(Schema.roles).where(eq(Schema.roles.name, role)).get();
     if (!roleExist) {
@@ -65,18 +56,9 @@ roleRoutes.post("/roles/assign", async (c) => {
   }
 });
 
-roleRoutes.post("/roles/delete", async (c) => {
+roleRoutes.post("/roles/delete", requireSession, requireRoles(["admin", "board"]), async (c) => {
   try {
     const { role, userId } = await c.req.json();
-    const cookie = c.req.header("Cookie") || "";
-    const sessionIDMatch = cookie.match(/sessionId=([^;]*)/);
-    if (!sessionIDMatch) {
-      return createErrorResponse(c, "INVALID_SESSION", "Missing or invalid session ID", 400);
-    }
-    const sessionID = sessionIDMatch[1];
-    if (!(await isAdmin(sessionID))) {
-      return createErrorResponse(c, "USER_NOT_ADMIN", "Deleting unauthorized: Admin role required", 403);
-    }
 
     const roleExist = await db.select().from(Schema.roles).where(eq(Schema.roles.name, role)).get();
     if (!roleExist) {
@@ -102,18 +84,5 @@ roleRoutes.post("/roles/delete", async (c) => {
     return createErrorResponse(c, "DELETE_ROLE_ERROR", "Failed to delete role", 500);
   }
 });
-
-export async function isAdmin(sessionId: string) {
-  const session = await db.select().from(Schema.sessions).where(eq(Schema.sessions.id, sessionId)).get();
-  if (!session) return false;
-
-  const userRoles = await db
-    .select({ role: Schema.userRoleRelationship.role })
-    .from(Schema.userRoleRelationship)
-    .where(eq(Schema.userRoleRelationship.userId, session.userId))
-    .all();
-
-  if (userRoles.some((r) => r.role === "admin" || r.role === "board")) return true;
-}
 
 export default roleRoutes;

--- a/src/server/api/user.ts
+++ b/src/server/api/user.ts
@@ -4,7 +4,7 @@ import { createErrorResponse, createSuccessResponse } from "@/shared/utils";
 import { userRoleRelationship, users } from "@db/tables";
 import type { User } from "@shared/schema/userSchema";
 import bcrypt from "bcryptjs";
-import { eq } from "drizzle-orm";
+import { eq, inArray } from "drizzle-orm";
 import { Hono } from "hono";
 
 const userRoutes = new Hono();
@@ -46,23 +46,31 @@ export const arrayToString = (arr: Array<string>): string => {
 userRoutes.get("/users", async (c) => {
   try {
     const rows = await db.select().from(users);
+    const userIds = rows.map((user) => user.id);
+
+    const roleRows = userIds.length
+      ? await db
+          .select({ userId: userRoleRelationship.userId, role: userRoleRelationship.role })
+          .from(userRoleRelationship)
+          .where(inArray(userRoleRelationship.userId, userIds))
+      : [];
+
+    const rolesByUser = new Map<string, Array<string>>();
+    for (const roleRow of roleRows) {
+      const existingRoles = rolesByUser.get(roleRow.userId) ?? [];
+      existingRoles.push(roleRow.role);
+      rolesByUser.set(roleRow.userId, existingRoles);
+    }
 
     // Get roles for each user
-    const usersWithRoles = await Promise.all(
-      rows.map(async (user) => {
-        const userRoles = await db
-          .select({ role: userRoleRelationship.role })
-          .from(userRoleRelationship)
-          .where(eq(userRoleRelationship.userId, user.id));
+    const usersWithRoles = rows.map((user) => {
+      const roleArray = rolesByUser.get(user.id) ?? [];
+      const roleString = arrayToString(roleArray);
 
-        const roleArray: Array<string> = userRoles.map((r) => r.role);
-        const roleString = arrayToString(roleArray);
-
-        // Initialize full Zod schema verified object with roles
-        const schemaUser: User = { ...user, roles: roleString };
-        return schemaUser;
-      }),
-    );
+      // Initialize full Zod schema verified object with roles
+      const schemaUser: User = { ...user, roles: roleString };
+      return schemaUser;
+    });
 
     return createSuccessResponse(c, usersWithRoles, "Fetched all users");
   } catch (err) {

--- a/src/server/middleware/auth.ts
+++ b/src/server/middleware/auth.ts
@@ -1,0 +1,71 @@
+import { db } from "@/server/db/db";
+import { createErrorResponse } from "@/shared/utils";
+import * as Schema from "@db/tables";
+import { eq } from "drizzle-orm";
+import { getCookie } from "hono/cookie";
+import { createMiddleware } from "hono/factory";
+
+export type Env = {
+  Variables: {
+    session: {
+      id: string;
+      userId: string;
+      expiresAt: number;
+    };
+  };
+};
+
+export const requireSession = createMiddleware<Env>(async (c, next) => {
+  const sessionId = getCookie(c, "sessionId");
+
+  if (!sessionId) {
+    return createErrorResponse(c, "NO_SESSION", "No active session", 401);
+  }
+
+  try {
+    const session = await db.select().from(Schema.sessions).where(eq(Schema.sessions.id, sessionId)).get();
+
+    if (!session) {
+      return createErrorResponse(c, "SESSION_NOT_FOUND", "Session not found", 401);
+    }
+
+    if (session.expiresAt < Date.now()) {
+      await db.delete(Schema.sessions).where(eq(Schema.sessions.id, sessionId));
+      return createErrorResponse(c, "SESSION_EXPIRED", "Session expired", 401);
+    }
+
+    c.set("session", session);
+    await next();
+  } catch (error) {
+    console.error("Session middleware error:", error);
+    return createErrorResponse(c, "SESSION_CHECK_ERROR", "Error checking session", 500);
+  }
+});
+
+export const requireRoles = (allowedRoles: Array<string>) =>
+  createMiddleware<Env>(async (c, next) => {
+    const session = c.get("session");
+
+    if (!session) {
+      return createErrorResponse(c, "UNAUTHORIZED", "Unauthorized: No user session found", 401);
+    }
+
+    try {
+      const userRoles = await db
+        .select({ role: Schema.userRoleRelationship.role })
+        .from(Schema.userRoleRelationship)
+        .where(eq(Schema.userRoleRelationship.userId, session.userId))
+        .all();
+
+      const hasRole = userRoles.some((r) => allowedRoles.includes(r.role));
+
+      if (!hasRole) {
+        return createErrorResponse(c, "FORBIDDEN", `Forbidden: Requires one of roles [${allowedRoles.join(", ")}]`, 403);
+      }
+
+      await next();
+    } catch (error) {
+      console.error("Role check error:", error);
+      return createErrorResponse(c, "ROLE_CHECK_ERROR", "Error checking roles", 500);
+    }
+  });

--- a/src/server/tests/events.test.ts
+++ b/src/server/tests/events.test.ts
@@ -1,0 +1,85 @@
+import { events as eventsTable } from "@/server/db/tables";
+import { createTestDatabase, resetTestDatabase } from "@/server/tests/testUtils";
+import type { Client } from "@libsql/client";
+import type { ErrorResponse, SuccessResponse } from "@schema/responseSchema";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, mock } from "bun:test";
+import { Hono } from "hono";
+
+let client: Client;
+let db: Awaited<ReturnType<typeof createTestDatabase>>["db"];
+let app: Hono;
+
+type EventRow = typeof eventsTable.$inferSelect;
+
+const toDate = (dateStr: string) => new Date(`${dateStr}T00:00:00.000Z`);
+
+const insertEvent = async (id: string, name: string, dateStr: string) => {
+  await db.insert(eventsTable).values({
+    id,
+    name,
+    description: "",
+    location: "Reitz Union",
+    startTime: toDate(dateStr),
+    endTime: toDate(dateStr),
+  });
+};
+
+describe("Events API", () => {
+  beforeAll(async () => {
+    ({ client, db } = await createTestDatabase());
+    mock.module("@/server/db/db", () => ({ db }));
+    const { default: eventsRoutes } = await import("@/server/api/events");
+    app = new Hono().route("/", eventsRoutes);
+  });
+
+  beforeEach(async () => {
+    ({ client, db } = await resetTestDatabase(client));
+    mock.module("@/server/db/db", () => ({ db }));
+  });
+
+  afterAll(() => {
+    client.close();
+  });
+
+  describe("GET /events with date filters", () => {
+    it("returns events inside the range and excludes events outside", async () => {
+      await insertEvent("event-a", "Event A", "2024-01-01");
+      await insertEvent("event-b", "Event B", "2024-06-15");
+      await insertEvent("event-c", "Event C", "2024-12-31");
+
+      const res = await app.request("/events?start_date=2024-01-01&end_date=2024-06-30");
+      expect(res.status).toBe(200);
+
+      const json = (await res.json()) as SuccessResponse;
+      const events = json.data as Array<EventRow>;
+      const eventNames = events.map((event) => event.name);
+
+      expect(eventNames).toContain("Event A");
+      expect(eventNames).toContain("Event B");
+      expect(eventNames).not.toContain("Event C");
+    });
+
+    it("returns all events when no date filters are provided", async () => {
+      await insertEvent("event-a", "Event A", "2024-01-01");
+      await insertEvent("event-b", "Event B", "2024-06-15");
+
+      const res = await app.request("/events");
+      expect(res.status).toBe(200);
+
+      const json = (await res.json()) as SuccessResponse;
+      const events = json.data as Array<EventRow>;
+      const eventNames = events.map((event) => event.name);
+
+      expect(eventNames).toContain("Event A");
+      expect(eventNames).toContain("Event B");
+    });
+
+    it("rejects invalid date formats", async () => {
+      const res = await app.request("/events?start_date=not-a-date&end_date=2024-06-30");
+      expect(res.status).toBe(400);
+
+      const json = (await res.json()) as ErrorResponse;
+      expect(json.error.errCode).toBe("DATE_FORMAT_INVALID");
+    });
+  });
+});

--- a/src/server/tests/mentorMentee.test.ts
+++ b/src/server/tests/mentorMentee.test.ts
@@ -1,0 +1,79 @@
+import { mentorMenteeRelationship, roles } from "@/server/db/tables";
+import { createTestDatabase, insertTestUser, resetTestDatabase } from "@/server/tests/testUtils";
+import type { Client } from "@libsql/client";
+import type { SuccessResponse } from "@schema/responseSchema";
+import { afterAll, beforeAll, beforeEach, describe, expect, it, mock } from "bun:test";
+import { Hono } from "hono";
+
+let client: Client;
+let db: Awaited<ReturnType<typeof createTestDatabase>>["db"];
+let app: Hono;
+
+const seedAdminAndMembers = async () => {
+  await db.insert(roles).values({ name: "admin" });
+
+  const adminId = "admin-user";
+  const mentorId = "mentor-user";
+  const menteeId = "mentee-user";
+
+  await insertTestUser(db, adminId, "adminUser", "admin@example.com", "P@ssword123", "admin");
+  await insertTestUser(db, mentorId, "mentorUser", "mentor@example.com");
+  await insertTestUser(db, menteeId, "menteeUser", "mentee@example.com");
+
+  return { adminId, mentorId, menteeId };
+};
+
+describe("Mentor/Mentee API", () => {
+  // NOTICE: if admin-only middleware exists for these routes, should need to update tests to authenticate as admin
+  beforeAll(async () => {
+    ({ client, db } = await createTestDatabase());
+    mock.module("@/server/db/db", () => ({ db }));
+    const { default: mentorMenteeRoutes } = await import("@/server/api/mentorMentee");
+    app = new Hono().route("/", mentorMenteeRoutes);
+  });
+
+  beforeEach(async () => {
+    ({ client, db } = await resetTestDatabase(client));
+    mock.module("@/server/db/db", () => ({ db }));
+  });
+
+  afterAll(() => {
+    client.close();
+  });
+
+  it("creates a mentor/mentee relationship", async () => {
+    const { menteeId, mentorId } = await seedAdminAndMembers();
+
+    const res = await app.request("/mentorMentee/single", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ mentorId, menteeId }),
+    });
+
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as SuccessResponse;
+    expect(json.message).toBe("Mentor/Mentee pair inserted successfully");
+
+    const relationships = await db.select().from(mentorMenteeRelationship);
+    expect(relationships).toHaveLength(1);
+    expect(relationships[0]).toMatchObject({ mentorId, menteeId });
+  });
+
+  it("lists mentor/mentee relationships after members are paired", async () => {
+    const { menteeId, mentorId } = await seedAdminAndMembers();
+
+    await app.request("/mentorMentee/single", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ mentorId, menteeId }),
+    });
+
+    const res = await app.request("/mentorMentee/all");
+    expect(res.status).toBe(200);
+
+    const json = (await res.json()) as SuccessResponse;
+    const relationships = json.data as Array<{ mentorId: string; menteeId: string }>;
+    expect(relationships).toHaveLength(1);
+    expect(relationships[0]).toMatchObject({ mentorId, menteeId });
+  });
+});


### PR DESCRIPTION
## 📝 Description

Resolves #461. Added two middleware functions pertaining to route protection that standardize API endpoint access. Then refactored 6 endpoints to use this middleware and removed redundant logic.

`requireSession` parses the `sessionId` cookie, validates the session against the database, and injects the session object into Hono context

`requireRoles` chains after `requireSession` and protects routes to be accessed only by users with specific roles

## 🧪 How to 

1. Pull this branch
2. Run `bun install`
3. Run `bun test`
