### PR TITLE
Draft for profile leaderboard

### DIFF
--- a/src/client/routeTree.gen.ts
+++ b/src/client/routeTree.gen.ts
@@ -44,6 +44,7 @@ import { Route as ProfileIndexImport } from './routes/profile/index'
 import { Route as ProfileSettingsImport } from './routes/profile/settings'
 import { Route as ProfileSecurityImport } from './routes/profile/security'
 import { Route as ProfileInfoImport } from './routes/profile/info'
+import { Route as ProfileAdminImport } from './routes/profile/admin'
 import { Route as UsersUsernameIdImport } from './routes/users/$username/$id'
 
 // Create/Update Routes
@@ -243,6 +244,12 @@ const ProfileSecurityRoute = ProfileSecurityImport.update({
 const ProfileInfoRoute = ProfileInfoImport.update({
   id: '/info',
   path: '/info',
+  getParentRoute: () => ProfileRouteRoute,
+} as any)
+
+const ProfileAdminRoute = ProfileAdminImport.update({
+  id: '/admin',
+  path: '/admin',
   getParentRoute: () => ProfileRouteRoute,
 } as any)
 
@@ -459,6 +466,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof WebdevImport
       parentRoute: typeof rootRoute
     }
+    '/profile/admin': {
+      id: '/profile/admin'
+      path: '/admin'
+      fullPath: '/profile/admin'
+      preLoaderRoute: typeof ProfileAdminImport
+      parentRoute: typeof ProfileRouteImport
+    }
     '/profile/info': {
       id: '/profile/info'
       path: '/info'
@@ -500,6 +514,7 @@ declare module '@tanstack/react-router' {
 // Create and export the route tree
 
 interface ProfileRouteRouteChildren {
+  ProfileAdminRoute: typeof ProfileAdminRoute
   ProfileInfoRoute: typeof ProfileInfoRoute
   ProfileSecurityRoute: typeof ProfileSecurityRoute
   ProfileSettingsRoute: typeof ProfileSettingsRoute
@@ -507,6 +522,7 @@ interface ProfileRouteRouteChildren {
 }
 
 const ProfileRouteRouteChildren: ProfileRouteRouteChildren = {
+  ProfileAdminRoute: ProfileAdminRoute,
   ProfileInfoRoute: ProfileInfoRoute,
   ProfileSecurityRoute: ProfileSecurityRoute,
   ProfileSettingsRoute: ProfileSettingsRoute,
@@ -547,6 +563,7 @@ export interface FileRoutesByFullPath {
   '/userpage': typeof UserpageRoute
   '/verify-email': typeof VerifyEmailRoute
   '/webdev': typeof WebdevRoute
+  '/profile/admin': typeof ProfileAdminRoute
   '/profile/info': typeof ProfileInfoRoute
   '/profile/security': typeof ProfileSecurityRoute
   '/profile/settings': typeof ProfileSettingsRoute
@@ -583,6 +600,7 @@ export interface FileRoutesByTo {
   '/userpage': typeof UserpageRoute
   '/verify-email': typeof VerifyEmailRoute
   '/webdev': typeof WebdevRoute
+  '/profile/admin': typeof ProfileAdminRoute
   '/profile/info': typeof ProfileInfoRoute
   '/profile/security': typeof ProfileSecurityRoute
   '/profile/settings': typeof ProfileSettingsRoute
@@ -621,6 +639,7 @@ export interface FileRoutesById {
   '/userpage': typeof UserpageRoute
   '/verify-email': typeof VerifyEmailRoute
   '/webdev': typeof WebdevRoute
+  '/profile/admin': typeof ProfileAdminRoute
   '/profile/info': typeof ProfileInfoRoute
   '/profile/security': typeof ProfileSecurityRoute
   '/profile/settings': typeof ProfileSettingsRoute
@@ -660,6 +679,7 @@ export interface FileRouteTypes {
     | '/userpage'
     | '/verify-email'
     | '/webdev'
+    | '/profile/admin'
     | '/profile/info'
     | '/profile/security'
     | '/profile/settings'
@@ -695,6 +715,7 @@ export interface FileRouteTypes {
     | '/userpage'
     | '/verify-email'
     | '/webdev'
+    | '/profile/admin'
     | '/profile/info'
     | '/profile/security'
     | '/profile/settings'
@@ -731,6 +752,7 @@ export interface FileRouteTypes {
     | '/userpage'
     | '/verify-email'
     | '/webdev'
+    | '/profile/admin'
     | '/profile/info'
     | '/profile/security'
     | '/profile/settings'
@@ -853,6 +875,7 @@ export const routeTree = rootRoute
     "/profile": {
       "filePath": "profile/route.tsx",
       "children": [
+        "/profile/admin",
         "/profile/info",
         "/profile/security",
         "/profile/settings",
@@ -939,6 +962,10 @@ export const routeTree = rootRoute
     },
     "/webdev": {
       "filePath": "webdev.tsx"
+    },
+    "/profile/admin": {
+      "filePath": "profile/admin.tsx",
+      "parent": "/profile"
     },
     "/profile/info": {
       "filePath": "profile/info.tsx",

--- a/src/client/routes/profile/admin.tsx
+++ b/src/client/routes/profile/admin.tsx
@@ -19,7 +19,7 @@ export const Route = createFileRoute("/profile/admin")({
 
     if (!isAdmin) return null;
     if (isLoading) return <div className="p-10 text-center">Loading users…</div>;
-    if (error) return <div className="p-10 text-red-600 font-bold">Error: {error.message}</div>;
+    if (error) return <div className="p-10 font-bold text-red-600">Error: {error.message}</div>;
 
     return (
       <div className="group mx-auto w-full max-w-5xl rounded-2xl bg-background px-4 py-6 shadow-xl md:px-10">
@@ -28,13 +28,9 @@ export const Route = createFileRoute("/profile/admin")({
           <h2 className="text-xl font-semibold">User Management</h2>
           <div className="flex w-full flex-col gap-6">
             {users && users.length > 0 ? (
-              users.map((user) => (
-                <AccountBox key={user.id} {...user} adminView={true} />
-              ))
+              users.map((user) => <AccountBox key={user.id} {...user} adminView={true} />)
             ) : (
-              <div className="rounded-lg border border-dashed border-gray-300 p-6 text-center text-gray-500">
-                No users found in the system.
-              </div>
+              <div className="rounded-lg border border-dashed border-gray-300 p-6 text-center text-gray-500">No users found in the system.</div>
             )}
           </div>
         </section>

--- a/src/client/routes/profile/admin.tsx
+++ b/src/client/routes/profile/admin.tsx
@@ -1,0 +1,44 @@
+// src/routes/profile/admin.tsx
+import AccountBox from "@/client/components/profile/AccountBox";
+import { useAuth } from "@hooks/AuthContext";
+import { useUsers } from "@hooks/useUsers";
+import { createFileRoute, useNavigate } from "@tanstack/react-router";
+import React, { useEffect } from "react";
+
+export const Route = createFileRoute("/profile/admin")({
+  component: () => {
+    const { id, isAdmin } = useAuth();
+    const { error, isLoading, users } = useUsers(id);
+    const navigate = useNavigate();
+
+    useEffect(() => {
+      if (!isAdmin) {
+        navigate({ to: "/profile", replace: true });
+      }
+    }, [isAdmin, navigate]);
+
+    if (!isAdmin) return null;
+    if (isLoading) return <div className="p-10 text-center">Loading users…</div>;
+    if (error) return <div className="p-10 text-red-600 font-bold">Error: {error.message}</div>;
+
+    return (
+      <div className="group mx-auto w-full max-w-5xl rounded-2xl bg-background px-4 py-6 shadow-xl md:px-10">
+        <section className="flex w-full flex-col space-y-4">
+          <h1 className="text-3xl font-bold text-saseBlue">Admin Dashboard</h1>
+          <h2 className="text-xl font-semibold">User Management</h2>
+          <div className="flex w-full flex-col gap-6">
+            {users && users.length > 0 ? (
+              users.map((user) => (
+                <AccountBox key={user.id} {...user} adminView={true} />
+              ))
+            ) : (
+              <div className="rounded-lg border border-dashed border-gray-300 p-6 text-center text-gray-500">
+                No users found in the system.
+              </div>
+            )}
+          </div>
+        </section>
+      </div>
+    );
+  },
+});

--- a/src/client/routes/profile/index.tsx
+++ b/src/client/routes/profile/index.tsx
@@ -44,8 +44,8 @@ export const Route = createFileRoute("/profile/")({
     };
 
     if (userLoading || loading) return <div className="p-10 text-center">Loading dashboard…</div>;
-    if (userError) return <div className="p-10 text-red-600 font-bold text-center">Error: {userError.message}</div>;
-    if (error) return <div className="p-10 text-red-600 font-bold text-center">Error: {error}</div>;
+    if (userError) return <div className="p-10 text-center font-bold text-red-600">Error: {userError.message}</div>;
+    if (error) return <div className="p-10 text-center font-bold text-red-600">Error: {error}</div>;
     if (!user) return <div className="p-10 text-center text-gray-500">User data unavailable</div>;
 
     return (
@@ -71,9 +71,19 @@ export const Route = createFileRoute("/profile/")({
                   <div className="flex items-center justify-between">
                     <h3 className="text-lg font-bold text-gray-900">Get more!</h3>
                   </div>
-                  
+
                   <button className="flex w-full items-center justify-center gap-2 rounded-xl bg-saseBlue py-3 font-bold text-white shadow-lg shadow-saseBlue/20 transition-all hover:scale-[1.02] hover:bg-blue-700 active:scale-95">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round">
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      width="20"
+                      height="20"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="3"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    >
                       <line x1="12" y1="5" x2="12" y2="19" />
                       <line x1="5" y1="12" x2="19" y2="12" />
                     </svg>
@@ -81,7 +91,8 @@ export const Route = createFileRoute("/profile/")({
                   </button>
 
                   <p className="text-xs leading-relaxed text-gray-400">
-                    Get point codes by attending <span className="font-semibold text-gray-600">SASE events</span> like GBMs, Workshops, and <span className="italic text-saseGreen">MORE!</span>
+                    Get point codes by attending <span className="font-semibold text-gray-600">SASE events</span> like GBMs, Workshops, and{" "}
+                    <span className="italic text-saseGreen">MORE!</span>
                   </p>
                 </div>
               </div>
@@ -101,7 +112,7 @@ export const Route = createFileRoute("/profile/")({
                   <div className="flex items-end justify-center gap-2 pt-10 md:gap-4">
                     {/* 2nd Place */}
                     <div className="flex flex-col items-center">
-                      <div className="flex h-24 w-20 flex-col items-center justify-start rounded-t-2xl bg-gray-100 shadow-inner md:w-28 md:h-32">
+                      <div className="flex h-24 w-20 flex-col items-center justify-start rounded-t-2xl bg-gray-100 shadow-inner md:h-32 md:w-28">
                         <span className="mt-4 text-3xl font-black text-gray-300">2</span>
                       </div>
                       <div className="mt-3 text-center">
@@ -112,7 +123,7 @@ export const Route = createFileRoute("/profile/")({
 
                     {/* 1st Place */}
                     <div className="flex flex-col items-center">
-                      <div className="relative flex h-36 w-24 flex-col items-center justify-start rounded-t-2xl bg-saseBlue shadow-xl md:w-32 md:h-44">
+                      <div className="relative flex h-36 w-24 flex-col items-center justify-start rounded-t-2xl bg-saseBlue shadow-xl md:h-44 md:w-32">
                         <span className="mt-8 text-4xl font-black text-white/20">1</span>
                       </div>
                       <div className="mt-3 text-center">
@@ -123,7 +134,7 @@ export const Route = createFileRoute("/profile/")({
 
                     {/* 3rd Place */}
                     <div className="flex flex-col items-center">
-                      <div className="flex h-16 w-20 flex-col items-center justify-start rounded-t-2xl bg-orange-50 shadow-inner md:w-28 md:h-24">
+                      <div className="flex h-16 w-20 flex-col items-center justify-start rounded-t-2xl bg-orange-50 shadow-inner md:h-24 md:w-28">
                         <span className="mt-4 text-3xl font-black text-orange-200">3</span>
                       </div>
                       <div className="mt-3 text-center">
@@ -146,9 +157,14 @@ export const Route = createFileRoute("/profile/")({
                       { rank: 9, name: "Kayla C.", points: "12" },
                       { rank: 10, name: "Pryanna P.", points: "10" },
                     ].map((entry) => (
-                      <div key={entry.rank} className="flex items-center justify-between rounded-xl bg-white p-4 shadow-sm transition-all hover:scale-[1.01] hover:shadow-md">
+                      <div
+                        key={entry.rank}
+                        className="flex items-center justify-between rounded-xl bg-white p-4 shadow-sm transition-all hover:scale-[1.01] hover:shadow-md"
+                      >
                         <div className="flex items-center gap-4">
-                          <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-gray-100 text-sm font-bold text-gray-500">{entry.rank}</span>
+                          <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-gray-100 text-sm font-bold text-gray-500">
+                            {entry.rank}
+                          </span>
                           <p className="font-semibold text-gray-900">{entry.name}</p>
                         </div>
                         <p className="font-bold text-saseBlue">{entry.points} pts</p>
@@ -195,7 +211,7 @@ export const Route = createFileRoute("/profile/")({
                               </button>
                               <button
                                 onClick={() => handleDecline(invite.id)}
-                                className="flex-1 rounded-lg bg-gray-100 px-4 py-2 text-xs font-bold text-gray-600 transition-all hover:bg-red-50 hover:text-red-600 active:scale-95 sm:shrink-0 sm:flex-none md:rounded-xl md:px-5 md:py-2 md:text-sm"
+                                className="flex-1 rounded-lg bg-gray-100 px-4 py-2 text-xs font-bold text-gray-600 transition-all hover:bg-red-50 hover:text-red-600 active:scale-95 sm:flex-none sm:shrink-0 md:rounded-xl md:px-5 md:py-2 md:text-sm"
                               >
                                 Decline
                               </button>

--- a/src/client/routes/profile/index.tsx
+++ b/src/client/routes/profile/index.tsx
@@ -1,9 +1,7 @@
 // src/routes/profile/index.tsx
 import { acceptMentorMenteeInvite, deleteMentorMenteeInvite, getAllMentorMenteeInvites } from "@/client/api/mentorMentee";
-import AccountBox from "@/client/components/profile/AccountBox";
 import { useAuth } from "@hooks/AuthContext";
 import { useUsers } from "@hooks/useUsers";
-import type { User } from "@shared/schema/userSchema";
 import { createFileRoute } from "@tanstack/react-router";
 import React, { useEffect, useState } from "react";
 
@@ -11,11 +9,10 @@ type Invite = { id: string; mentorId: string; menteeId: string };
 
 export const Route = createFileRoute("/profile/")({
   component: () => {
-    const { id, isAdmin } = useAuth();
-    const { error: userError, isLoading: userLoading, isLoadingUsers, user, users } = useUsers(id);
+    const { id } = useAuth();
+    const { error: userError, isLoading: userLoading, user } = useUsers(id);
 
     const [invites, setInvites] = useState<Array<Invite>>([]);
-    const [allUsers, setAllUsers] = useState<Array<User>>([]);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState<string | null>(null);
 
@@ -27,20 +24,7 @@ export const Route = createFileRoute("/profile/")({
         .then(setInvites)
         .catch(() => setError("Failed to load invites"))
         .finally(() => setLoading(false));
-      try {
-        setLoading(true);
-        console.log(users);
-        const userArray: Array<User> = [];
-        users?.forEach((user) => {
-          const userObj: User = { ...user, password: "······" };
-          userArray.push(userObj);
-        });
-        setAllUsers(userArray);
-        console.log(allUsers);
-      } catch {
-        setError("Failed to retrieve all users list");
-      }
-    }, [id, isLoadingUsers]);
+    }, [id]);
 
     const handleAccept = async (inviteId: string) => {
       try {
@@ -59,70 +43,199 @@ export const Route = createFileRoute("/profile/")({
       }
     };
 
-    if (userLoading || loading) return <div>Loading…</div>;
-    if (userError) return <div className="text-red-600">Error: {userError.message}</div>;
-    if (error) return <div className="text-red-600">Error: {error}</div>;
-    if (!user) return <div>User data unavailable</div>;
+    if (userLoading || loading) return <div className="p-10 text-center">Loading dashboard…</div>;
+    if (userError) return <div className="p-10 text-red-600 font-bold text-center">Error: {userError.message}</div>;
+    if (error) return <div className="p-10 text-red-600 font-bold text-center">Error: {error}</div>;
+    if (!user) return <div className="p-10 text-center text-gray-500">User data unavailable</div>;
 
     return (
-      <div className="group mx-auto w-full max-w-5xl rounded-2xl bg-background px-4 py-6 shadow-xl md:px-10">
-        {/* Centered card just like AccountBox */}
-        <h1 className="pb-6 text-xl font-bold">Dashboard</h1>
-
-        {/* Pending Invites */}
-        <section className="space-y-4 pb-10">
-          <h2 className="text-xl font-semibold">Pending Invites</h2>
-          {invites.length === 0 ? (
-            <div className="rounded-lg border border-dashed border-gray-300 p-6 text-center text-gray-500">No pending invites.</div>
-          ) : (
-            <ul className="space-y-3">
-              {invites.map((invite) => (
-                <li key={invite.id} className="flex items-center justify-between rounded-lg border px-4 py-3">
-                  <span>
-                    Invite from <strong>{invite.mentorId}</strong>
-                  </span>
-                  <div className="space-x-2">
-                    <button onClick={() => handleAccept(invite.id)} className="rounded bg-green-500 px-3 py-1 text-white hover:bg-green-600">
-                      Accept
-                    </button>
-                    <button onClick={() => handleDecline(invite.id)} className="rounded bg-red-500 px-3 py-1 text-white hover:bg-red-600">
-                      Decline
-                    </button>
-                  </div>
-                </li>
-              ))}
-            </ul>
-          )}
-        </section>
-
-        {/* Roles (placeholder) */}
-        {isAdmin && (
-          <section className="flex w-full flex-col space-y-4">
-            <h1 className="text-3xl font-bold text-saseBlue">Admin Dashboard</h1>
-            <h2 className="text-xl font-semibold">Users</h2>
-            {loading ? (
-              <p>Loading users...</p>
-            ) : (
-              <div className="flex w-full flex-col gap-6">
-                {users != undefined ? (
-                  users.length > 0 ? (
-                    users.map((user) => <AccountBox key={user.id} {...user} adminView={true} />)
-                  ) : (
-                    <p>No Users found</p>
-                  )
-                ) : (
-                  <div>Users could not be loaded</div>
-                )}
+      <div className="mx-auto w-full max-w-6xl px-2 py-4 md:px-4 md:py-8">
+        <div className="flex flex-col gap-6 md:flex-row md:gap-8">
+          {/* Left Subbox - 1/3 width */}
+          <aside className="w-full md:w-1/3">
+            <div className="h-full rounded-2xl border border-gray-100 bg-white p-6 shadow-xl shadow-gray-200/40 md:rounded-3xl md:p-8 md:shadow-2xl md:shadow-gray-200/50">
+              <div className="mb-6 md:mb-8">
+                <h2 className="text-xl font-bold tracking-tight text-saseBlue md:text-2xl">SASE Points</h2>
+                <div className="mt-2 h-1 w-12 rounded-full bg-saseGreen"></div>
               </div>
-            )}
-          </section>
-        )}
 
-        {/* Customization (placeholder) */}
-        <section className="space-y-4">
-          <h2 className="text-xl font-semibold">Customization</h2>
-          <div className="rounded-lg border border-dashed border-gray-300 p-6 text-center text-gray-500">Nothing to configure yet.</div>
-        </section>
+              <div className="space-y-8">
+                <div className="text-center">
+                  <p className="text-6xl font-black text-saseBlue md:text-8xl">4</p>
+                  <p className="mt-2 font-bold uppercase tracking-widest text-saseBlue/40">Total Points</p>
+                </div>
+
+                <hr className="border-gray-100" />
+
+                <div className="space-y-4">
+                  <div className="flex items-center justify-between">
+                    <h3 className="text-lg font-bold text-gray-900">Get more!</h3>
+                  </div>
+                  
+                  <button className="flex w-full items-center justify-center gap-2 rounded-xl bg-saseBlue py-3 font-bold text-white shadow-lg shadow-saseBlue/20 transition-all hover:scale-[1.02] hover:bg-blue-700 active:scale-95">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round">
+                      <line x1="12" y1="5" x2="12" y2="19" />
+                      <line x1="5" y1="12" x2="19" y2="12" />
+                    </svg>
+                    Input Code
+                  </button>
+
+                  <p className="text-xs leading-relaxed text-gray-400">
+                    Get point codes by attending <span className="font-semibold text-gray-600">SASE events</span> like GBMs, Workshops, and <span className="italic text-saseGreen">MORE!</span>
+                  </p>
+                </div>
+              </div>
+            </div>
+          </aside>
+
+          {/* Right Subbox - 2/3 width */}
+          <main className="w-full md:w-2/3">
+            <div className="rounded-2xl border border-gray-100 bg-white p-6 shadow-xl shadow-gray-200/40 md:rounded-3xl md:p-12 md:shadow-2xl md:shadow-gray-200/50">
+              <header className="mb-6 md:mb-8">
+                <h1 className="text-2xl font-black tracking-tighter text-saseBlue md:text-4xl">SASE Leaderboard</h1>
+              </header>
+
+              <div className="space-y-10">
+                {/* Podium Section */}
+                <section>
+                  <div className="flex items-end justify-center gap-2 pt-10 md:gap-4">
+                    {/* 2nd Place */}
+                    <div className="flex flex-col items-center">
+                      <div className="flex h-24 w-20 flex-col items-center justify-start rounded-t-2xl bg-gray-100 shadow-inner md:w-28 md:h-32">
+                        <span className="mt-4 text-3xl font-black text-gray-300">2</span>
+                      </div>
+                      <div className="mt-3 text-center">
+                        <p className="text-sm font-bold text-gray-700">Leann T.</p>
+                        <p className="text-xs font-medium text-saseBlue">24 pts</p>
+                      </div>
+                    </div>
+
+                    {/* 1st Place */}
+                    <div className="flex flex-col items-center">
+                      <div className="relative flex h-36 w-24 flex-col items-center justify-start rounded-t-2xl bg-saseBlue shadow-xl md:w-32 md:h-44">
+                        <span className="mt-8 text-4xl font-black text-white/20">1</span>
+                      </div>
+                      <div className="mt-3 text-center">
+                        <p className="text-base font-black text-gray-900">Justin D.</p>
+                        <p className="text-sm font-bold text-saseBlue">29 pts</p>
+                      </div>
+                    </div>
+
+                    {/* 3rd Place */}
+                    <div className="flex flex-col items-center">
+                      <div className="flex h-16 w-20 flex-col items-center justify-start rounded-t-2xl bg-orange-50 shadow-inner md:w-28 md:h-24">
+                        <span className="mt-4 text-3xl font-black text-orange-200">3</span>
+                      </div>
+                      <div className="mt-3 text-center">
+                        <p className="text-sm font-bold text-gray-700">Manav S.</p>
+                        <p className="text-xs font-medium text-saseBlue">21 pts</p>
+                      </div>
+                    </div>
+                  </div>
+                </section>
+
+                {/* Leaderboard List */}
+                <section className="rounded-3xl bg-gray-50/50 p-3 md:p-6">
+                  <div className="space-y-2">
+                    {[
+                      { rank: 4, name: "Kevin T.", points: "20" },
+                      { rank: 5, name: "Helen Z.", points: "18" },
+                      { rank: 6, name: "Adriel P.", points: "17" },
+                      { rank: 7, name: "Michael H.", points: "15" },
+                      { rank: 8, name: "Logan T.", points: "14" },
+                      { rank: 9, name: "Kayla C.", points: "12" },
+                      { rank: 10, name: "Pryanna P.", points: "10" },
+                    ].map((entry) => (
+                      <div key={entry.rank} className="flex items-center justify-between rounded-xl bg-white p-4 shadow-sm transition-all hover:scale-[1.01] hover:shadow-md">
+                        <div className="flex items-center gap-4">
+                          <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-gray-100 text-sm font-bold text-gray-500">{entry.rank}</span>
+                          <p className="font-semibold text-gray-900">{entry.name}</p>
+                        </div>
+                        <p className="font-bold text-saseBlue">{entry.points} pts</p>
+                      </div>
+                    ))}
+                  </div>
+                </section>
+
+                {/* Personal Actions */}
+                <div className="space-y-12 border-t border-gray-100 pt-16">
+                  {/* Pending Invites */}
+                  <section>
+                    <div className="mb-6 flex items-center justify-between">
+                      <h2 className="text-xl font-bold text-gray-900 md:text-2xl">Personal Invites</h2>
+                      <span className="rounded-full bg-saseGreen/10 px-3 py-1 text-xs font-bold text-saseGreen">{invites.length} New</span>
+                    </div>
+
+                    {invites.length === 0 ? (
+                      <div className="rounded-2xl border border-dashed border-gray-200 bg-gray-50/50 p-8 text-center md:p-10">
+                        <p className="text-sm font-medium text-gray-400 md:text-base">No pending invites at the moment.</p>
+                      </div>
+                    ) : (
+                      <ul className="grid gap-4">
+                        {invites.map((invite) => (
+                          <li
+                            key={invite.id}
+                            className="flex flex-col gap-4 rounded-xl border border-gray-100 bg-white p-4 shadow-sm transition-all hover:shadow-md sm:flex-row sm:items-center sm:justify-between md:rounded-2xl md:p-6"
+                          >
+                            <div className="flex items-center gap-3 md:gap-4">
+                              <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-saseBlue/10 text-saseBlue md:h-12 md:w-12">
+                                <span className="text-sm font-bold md:text-base">{invite.mentorId.charAt(0).toUpperCase()}</span>
+                              </div>
+                              <div className="min-w-0 flex-1">
+                                <p className="truncate font-semibold text-gray-900">Invite from {invite.mentorId}</p>
+                                <p className="text-xs text-gray-500 md:text-sm">Mentor Request</p>
+                              </div>
+                            </div>
+                            <div className="flex gap-2 sm:shrink-0">
+                              <button
+                                onClick={() => handleAccept(invite.id)}
+                                className="flex-1 rounded-lg bg-saseGreen px-4 py-2 text-xs font-bold text-white transition-all hover:bg-green-600 hover:shadow-lg active:scale-95 sm:flex-none md:rounded-xl md:px-5 md:py-2 md:text-sm"
+                              >
+                                Accept
+                              </button>
+                              <button
+                                onClick={() => handleDecline(invite.id)}
+                                className="flex-1 rounded-lg bg-gray-100 px-4 py-2 text-xs font-bold text-gray-600 transition-all hover:bg-red-50 hover:text-red-600 active:scale-95 sm:shrink-0 sm:flex-none md:rounded-xl md:px-5 md:py-2 md:text-sm"
+                              >
+                                Decline
+                              </button>
+                            </div>
+                          </li>
+                        ))}
+                      </ul>
+                    )}
+                  </section>
+
+                  {/* Customization */}
+                  <section>
+                    <div className="mb-6">
+                      <h2 className="text-xl font-bold text-gray-900 md:text-2xl">Customization</h2>
+                    </div>
+                    <div className="rounded-2xl border border-dashed border-gray-200 bg-gray-50/30 p-8 text-center md:p-12">
+                      <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-gray-100 text-gray-400">
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          width="32"
+                          height="32"
+                          viewBox="0 0 24 24"
+                          fill="none"
+                          stroke="currentColor"
+                          strokeWidth="2"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                        >
+                          <path d="M12 20h9" />
+                          <path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z" />
+                        </svg>
+                      </div>
+                      <p className="font-medium text-gray-500">More customization options coming soon!</p>
+                    </div>
+                  </section>
+                </div>
+              </div>
+            </div>
+          </main>
+        </div>
       </div>
     );
   },


### PR DESCRIPTION
## 📝 Description

This PR adds a rough draft of the SASE Points and SASE Leaderboard visuals on the profile dashboard page. It also separates the admin's user management info into a separate subtab on profile.

---

## 🔗 Related Issue(s)

> Fixes #512 

---

## 🧪 How to Test

Include clear steps so reviewers can verify your changes.

**Example:**

1. Pull this branch
2. Run `bun install` and `bun dev`
3. Navigate to `/profile`
4. Verify that the leaderboard and points load on the dashboard subtab
5. If testing from an admin account, verify that the admin subtab leads to user management info

---

## 📸 Screenshots (if applicable)

Before: 
<img width="3420" height="1904" alt="image" src="https://github.com/user-attachments/assets/fd6065d7-e5cc-4380-a084-9bc59cef82b4" />

After:
<img width="3420" height="1904" alt="image" src="https://github.com/user-attachments/assets/4bf448b3-04ab-44b9-b56c-26cecc82b2f3" />
<img width="3420" height="1904" alt="image" src="https://github.com/user-attachments/assets/8482e5c4-dce2-4f94-bf20-3fb6c37fd6ec" />

---

## ✅ Checklist

Please confirm all the following before requesting review:

- My code follows the project’s coding conventions ✓
- I ran `bun fix` and fixed all warnings/errors ✓
- I’ve tested the changes locally ✓
- I’ve added or updated comments and documentation where needed ✓
- This PR is ready for review ✓

---