### PR TITLE
Restyled Alumni Bank & Glass Effect on Profile Pages

### DIFF
--- a/src/client/components/profile/ProfileNav.tsx
+++ b/src/client/components/profile/ProfileNav.tsx
@@ -24,7 +24,7 @@ const ProfileNav: React.FC<{ profileName?: string }> = ({ profileName = "User" }
   };
 
   return (
-    <div className="flex w-full flex-col bg-background font-redhat md:w-60 md:rounded-3xl md:p-6 md:shadow-xl">
+    <div className="flex w-full flex-col border border-white bg-transparent font-redhat md:w-60 md:rounded-3xl md:p-6 md:shadow-xl">
       {/* Profile Info - Hidden on Mobile Top Nav to save space */}
       <div className="mb-6 hidden flex-col items-center text-center md:flex">
         <div className="flex h-32 w-32 items-center justify-center rounded-full bg-saseBlueLight text-white shadow-inner">
@@ -35,7 +35,7 @@ const ProfileNav: React.FC<{ profileName?: string }> = ({ profileName = "User" }
       </div>
 
       {/* Navigation Links: Horizontal scroll on mobile, Vertical list on desktop */}
-      <nav className="no-scrollbar flex flex-row overflow-x-auto border-b md:flex-col md:space-y-2 md:border-none">
+      <nav className="no-scrollbar flex flex-row overflow-x-auto border-b bg-transparent md:flex-col md:space-y-2 md:border-none">
         {NAV_ITEMS.map((item) => (
           <NavItem key={item.to} {...item} />
         ))}
@@ -49,7 +49,7 @@ const ProfileNav: React.FC<{ profileName?: string }> = ({ profileName = "User" }
       </nav>
 
       {/* Desktop Logout Button */}
-      <div className="hidden md:mt-10 md:flex md:justify-center">
+      <div className="hidden bg-transparent md:mt-10 md:flex md:justify-center">
         <Button variant="destructive" size="sm" onClick={handleLogout} className="w-full">
           Log Out
         </Button>
@@ -65,22 +65,20 @@ const NavItem: React.FC<{ to: string; icon: string; text: string; color: string;
       activeOptions={{ exact: to === "/profile" }} // Ensures Dashboard isn't always active
       className="group relative flex items-center space-x-2 px-6 py-4 transition-all md:rounded-xl md:px-4 md:py-3"
       activeProps={{
-        className: cn("bg-gray-50 md:bg-muted", color, "font-bold"),
+        className: cn("border", "border-white", color, "font-bold"),
       }}
     >
       {({ isActive }) => (
         <>
-          <Icon icon={icon} className={cn("text-2xl transition-colors", isActive ? color : "group-hover: text-gray-400" + color)} />
+          <Icon icon={icon} className={cn("text-2xl transition-colors", isActive ? "text-black" : "group-hover: text-gray-400")} />
           <span
             className={cn(
               "whitespace-nowrap text-sm font-medium transition-colors",
-              isActive ? `text-${color}` : "text-gray-500 group-hover:text-gray-900 dark:group-hover:text-white",
+              isActive ? `font-bold text-black` : "text-black group-hover:text-gray-900 dark:group-hover:text-white",
             )}
           >
             {text}
           </span>
-          {/* Active indicator line (Bottom for mobile, Left for desktop) */}
-          {isActive && <div className={cn("absolute bottom-0 left-0 h-1 w-full md:bottom-auto md:left-0 md:h-full md:w-1", border)} />}
         </>
       )}
     </Link>

--- a/src/client/components/profile/SecurityBox.tsx
+++ b/src/client/components/profile/SecurityBox.tsx
@@ -9,7 +9,7 @@ const SecurityBox: React.FC = () => {
   };
 
   return (
-    <div className="group mx-auto w-full max-w-5xl rounded-2xl bg-background px-4 py-6 shadow-xl md:px-10">
+    <div className="group mx-auto w-full max-w-5xl rounded-2xl border border-white bg-transparent px-4 py-6 shadow-xl md:px-10">
       <h2 className="mb-6 text-xl font-bold">Security</h2>
 
       <div className="flex justify-between">

--- a/src/client/components/profile/SettingsBox.tsx
+++ b/src/client/components/profile/SettingsBox.tsx
@@ -71,7 +71,7 @@ const SettingsBox: React.FC<SettingsBoxProps> = ({ darkMode, email, firstName, l
   };
 
   return (
-    <div className="group w-full rounded-2xl bg-background shadow-xl">
+    <div className="group w-full rounded-2xl bg-transparent">
       {/* Main Header */}
       <h1 className="mb-6 text-xl font-bold">Settings</h1>
 

--- a/src/client/components/profile/UserInfoBox.tsx
+++ b/src/client/components/profile/UserInfoBox.tsx
@@ -150,7 +150,7 @@ export default function UserInfoBox(props: UserInfoBoxProps) {
   };
 
   return (
-    <div className="group mx-auto w-full max-w-5xl rounded-2xl bg-background px-4 py-6 shadow-xl md:px-10">
+    <div className="group mx-auto w-full max-w-5xl rounded-2xl border border-white bg-transparent px-4 py-6 shadow-xl md:px-10">
       <ConfigurableAccountBox title="Profile Information" initialData={initialData} fieldConfigs={fieldConfigs} onSave={handleSave} />
     </div>
   );

--- a/src/client/routes/profile/alumni-bank.tsx
+++ b/src/client/routes/profile/alumni-bank.tsx
@@ -48,7 +48,7 @@ function AlumniBankPage() {
   if (error) return <div className="p-10 text-center text-red-600">Error: {(error as Error).message}</div>;
 
   return (
-    <div className="group mx-auto w-full max-w-7xl rounded-2xl bg-background px-4 py-6 shadow-xl md:px-10">
+    <div className="group mx-auto w-full max-w-7xl rounded-2xl border border-white bg-transparent px-4 py-6 shadow-xl md:px-10">
       <h1 className="pb-6 text-xl font-bold">Alumni Bank</h1>
 
       {isAdmin && (
@@ -56,7 +56,7 @@ function AlumniBankPage() {
           <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
             <div>
               <h2 className="text-lg font-semibold">Alumni Bank Update</h2>
-              <p className="text-sm text-gray-500">Manual refresh from configured LinkedIn MCP.</p>
+              <p className="text-sm italic">Manual refresh from configured LinkedIn MCP.</p>
             </div>
             <button
               onClick={() => triggerRefresh.mutate()}
@@ -117,34 +117,32 @@ function AlumniBankPage() {
 
       {data && data.length > 0 ? (
         <div className="overflow-x-auto rounded-xl border">
-          <table className="min-w-[1200px] divide-y divide-gray-200 text-left text-sm">
-            <thead className="bg-muted">
+          <table className="w-full text-left text-sm">
+            <thead className="bg-gray-200 dark:text-black">
               <tr>
-                <th className="px-4 py-3 font-semibold">Name</th>
-                <th className="px-4 py-3 font-semibold">Major</th>
-                <th className="px-4 py-3 font-semibold">Minor</th>
-                <th className="px-4 py-3 font-semibold">Graduation Month</th>
-                <th className="px-4 py-3 font-semibold">Graduation Year</th>
-                <th className="px-4 py-3 font-semibold">Current Role</th>
-                <th className="px-4 py-3 font-semibold">Current Company</th>
-                <th className="px-4 py-3 font-semibold">Past Companies</th>
-                <th className="px-4 py-3 font-semibold">Email</th>
-                <th className="px-4 py-3 font-semibold">LinkedIn</th>
+                <th className="px-4 py-2 font-semibold">Name</th>
+                <th className="px-4 py-2 font-semibold">Major</th>
+                <th className="px-4 py-2 font-semibold">Graduation</th>
+                <th className="px-4 py-2 font-semibold">Current Role</th>
+                <th className="px-4 py-2 font-semibold">Past Companies</th>
+                <th className="px-4 py-2 font-semibold">Email</th>
+                <th className="px-4 py-2 font-semibold">LinkedIn</th>
               </tr>
             </thead>
             <tbody className="divide-y divide-gray-100">
               {data.map((row) => (
                 <tr key={row.id}>
-                  <td className="px-4 py-3">{row.name}</td>
-                  <td className="px-4 py-3">{row.major}</td>
-                  <td className="px-4 py-3">{row.minor}</td>
-                  <td className="px-4 py-3">{row.graduationMonth}</td>
-                  <td className="px-4 py-3">{row.graduationYear}</td>
-                  <td className="px-4 py-3">{row.currentRole}</td>
-                  <td className="px-4 py-3">{row.currentCompany}</td>
-                  <td className="px-4 py-3">{row.pastCompanies.join(", ") || "—"}</td>
-                  <td className="px-4 py-3">{row.email}</td>
-                  <td className="px-4 py-3">
+                  <td className="px-4 py-2">{row.name}</td>
+                  <td className="px-4 py-2">{row.major}</td>
+                  <td className="px-4 py-2">
+                    {row.graduationMonth} {row.graduationYear}
+                  </td>
+                  <td className="px-4 py-2">
+                    {row.currentRole} @ {row.currentCompany}
+                  </td>
+                  <td className="px-4 py-2">{row.pastCompanies.join(", ") || "—"}</td>
+                  <td className="px-4 py-2">{row.email}</td>
+                  <td className="px-4 py-2">
                     {row.linkedin.trim() ? (
                       <a href={row.linkedin} target="_blank" rel="noreferrer" className="inline-flex items-center text-[#0A66C2] hover:opacity-80">
                         <Icon icon="mdi:linkedin" className="text-xl" />

--- a/src/client/routes/profile/index.tsx
+++ b/src/client/routes/profile/index.tsx
@@ -65,7 +65,7 @@ export const Route = createFileRoute("/profile/")({
     if (!user) return <div>User data unavailable</div>;
 
     return (
-      <div className="group mx-auto w-full max-w-5xl rounded-2xl bg-background px-4 py-6 shadow-xl md:px-10">
+      <div className="group mx-auto w-full max-w-5xl rounded-2xl border border-white bg-transparent px-4 py-6 shadow-xl md:px-10">
         {/* Centered card just like AccountBox */}
         <h1 className="pb-6 text-xl font-bold">Dashboard</h1>
 

--- a/src/client/routes/profile/route.tsx
+++ b/src/client/routes/profile/route.tsx
@@ -29,7 +29,7 @@ export const Route = createFileRoute("/profile")({
     if (!user) return <div className="p-10 text-center">User data unavailable</div>;
 
     return (
-      <div className="flex min-h-screen w-full flex-col bg-muted md:flex-row md:gap-6 md:p-10">
+      <div className="ombre-background flex min-h-screen w-full flex-col bg-muted md:flex-row md:gap-6 md:p-10">
         {errorMessage && (
           <div className="fixed right-4 top-4 z-50 rounded border border-red-200 bg-red-100 p-3 text-red-700 shadow-lg">{errorMessage}</div>
         )}
@@ -38,7 +38,7 @@ export const Route = createFileRoute("/profile")({
             - On mobile: Sticky at the top with a horizontal scroll if links overflow.
             - On desktop: Fixed width sidebar.
         */}
-        <aside className="sticky top-0 z-10 w-full border-b bg-background md:relative md:top-auto md:w-64 md:flex-shrink-0 md:rounded-xl md:border-none md:bg-transparent">
+        <aside className="sticky top-0 z-10 w-full border-b bg-transparent md:relative md:top-auto md:w-64 md:flex-shrink-0 md:rounded-xl md:border-none md:bg-transparent">
           <ProfileNav profileName={user.username} />
         </aside>
 

--- a/src/client/routes/profile/settings.tsx
+++ b/src/client/routes/profile/settings.tsx
@@ -19,7 +19,7 @@ export const Route = createFileRoute("/profile/settings")({
     if (!user) return <div className="p-10 text-center">User data unavailable</div>;
 
     return (
-      <div className="group mx-auto w-full max-w-5xl rounded-2xl bg-background px-4 py-6 shadow-xl md:px-10">
+      <div className="group mx-auto w-full max-w-5xl rounded-2xl border border-white bg-transparent px-4 py-6 shadow-xl md:px-10">
         <SettingsBox
           darkMode={darkMode}
           toggleDarkMode={toggleDarkMode}


### PR DESCRIPTION
## 📝 Description

Please provide a clear and concise description of what your pull request does.

> This PR subtly restyles the alumni bank, removing the option for a minor & combining the Graduation month/year and Current role/company columns. It also adds the glass effect to all the profile pages, making the background ombre and the profile components transparent.

---

## 🔗 Related Issue(s)

If this PR fixes or relates to an open issue, reference it here:

**Example:**

> Addresses #514

---

## 🧪 How to Test

Include clear steps so reviewers can verify your changes.

**Example:**

1. Pull this branch
2. Run `bun install` and `bun dev`
3. Login to an account
4. Navigate to `/profile`
5. Verify that all the profile tabs display properly & the alumni bank displays the accurate information

---

## 📸 Screenshots (if applicable)

If your change affects the UI, attach **before and after screenshots**.

---

## ✅ Checklist

Please confirm all the following before requesting review:

- My code follows the project’s coding conventions
- I ran `bun fix` and fixed all warnings/errors
- I’ve tested the changes locally
- I’ve added or updated comments and documentation where needed
- This PR is ready for review

---

## Additional Notes (Optional)

Add anything else the reviewers should know.  
(e.g., follow-up tasks, known issues, blockers, or special setup notes)

---
